### PR TITLE
Admin tools

### DIFF
--- a/src/plugin/modules/components/controller.js
+++ b/src/plugin/modules/components/controller.js
@@ -20,12 +20,14 @@ define([
             this.feedsApi = FeedsAPI.make(runtime.getConfig('services.feeds.url'), this.token);
             let loader = Util.loadingElement('5x');
             this.feedData = {};
+            this.isAdmin = false;
 
             this.element.appendChild(loader);
             this.initializeData()
                 .then((feedData) => {
                     this.element.innerHTML = '';
                     if (runtime.service('session').getCustomRoles().includes('FEEDS_ADMIN')) {
+                        this.isAdmin = true;
                         this.globalPoster = new GlobalPoster({
                             afterSubmitFn: this.refreshFeed.bind(this),
                             runtime: runtime
@@ -50,7 +52,8 @@ define([
                         feedUpdateFn: this.updateFeed.bind(this),
                         unseen: unseenSet,
                         globalFeed: feedData.global.feed,
-                        runtime: runtime
+                        runtime: runtime,
+                        isAdmin: this.isAdmin
                     });
                     this.element.appendChild(this.feedTabs.element);
                 });

--- a/src/plugin/modules/components/feedTabs.js
+++ b/src/plugin/modules/components/feedTabs.js
@@ -23,6 +23,7 @@ define([
          *
          */
         constructor(config) {
+            this.isAdmin = config.isAdmin;
             this.runtime = config.runtime;
             this.feedUpdateFn = config.feedUpdateFn;
             let feeds = config.feeds;
@@ -89,14 +90,16 @@ define([
 
         renderFeed() {
             console.log(this.notes);
-            let contentPane = this.element.querySelector('.feed-content');
+            let contentPane = this.element.querySelector('.feed-content'),
+                curFeed = this.getCurrentFeedId(),
+                toggleSeenFn = curFeed !== 'global' ? this.toggleSeen.bind(this) : null,
+                expireNoteFn = curFeed === 'global' ? this.expireNote.bind(this) : null;
             contentPane.innerHTML = '';
-            let toggleSeenFn = this.getCurrentFeedId() !== 'global' ? this.toggleSeen.bind(this) : null;
             if (!this.notes || this.notes.length === 0) {
                 contentPane.innerHTML = this.emptyNotification();
             }
             this.notes.forEach(note => {
-                let noteObj = new Notification(note, toggleSeenFn);
+                let noteObj = new Notification(note, toggleSeenFn, expireNoteFn);
                 contentPane.appendChild(noteObj.element);
             });
         }
@@ -112,6 +115,10 @@ define([
                     You have no notifications to view!
                 </div>
             </div>`;
+        }
+
+        expireNote(note) {
+            alert("expiring notification " + note.id);
         }
 
         toggleSeen(note) {
@@ -150,9 +157,6 @@ define([
          * KVP - keys = key name of feeds, values = number of unseen
          */
         setUnseenCounts(unseen) {
-            // this.element
-            //     .querySelectorAll('.feed-tabs span.badge')
-            //     .forEach(n => n.style.display='none');
             for (const feedKey in unseen) {
                 let count = unseen[feedKey];
                 let badge = this.element.querySelector(`.feed-tabs div[data-name=${feedKey}] span.badge`);

--- a/src/plugin/modules/components/feedTabs.js
+++ b/src/plugin/modules/components/feedTabs.js
@@ -167,10 +167,17 @@ define([
         }
 
         refresh(feed) {
-            // this.removeSeenTimeout();
+            if (!feed) {
+                return;
+            }
+            if (!feed.feed) {
+                let curId = this.getCurrentFeedId();
+                if (feed[curId]) {
+                    feed = feed[curId];
+                }
+            }
             this.notes = feed.feed;
             this.renderFeed();
-            // this.initSeenTimeout();
         }
 
         removeSeenTimeout() {

--- a/src/plugin/modules/components/globalPoster.js
+++ b/src/plugin/modules/components/globalPoster.js
@@ -21,6 +21,23 @@ define([
                 config.afterSubmitFn({});
             };
 
+            let curDate = new Date(),
+                defaultExp = new Date(curDate.getTime() + (30 * 24 * 60 * 60 * 1000));
+
+            let OLD = `
+                <div class='form-group mx-sm-3 mb-2'>
+                    <label for="verb-select"><b>Verb</b> - this tells the notification what's happening.</label>
+                    <select class="form-control custom-select" id="verb-select">
+                        ${verbs.map(verb => `<option value="${verb}">${verb}</option>`)}
+                    </select>
+                </div>
+                <div class='form-group mx-sm-3 mb-2'>
+                    <label for="object-input"><b>Object</b> - this field sets the notification to what the event is affecting.</label>
+                    <input class="form-control" id="object-input" placeholder="Enter object" />
+                    <small class="form-text text-muted"></small>
+                </div>
+            `;
+
             this.element.innerHTML = `
                 <div class='panel-heading'>
                     <b>Create Global Notification</b> - create a new global notification. Everyone gets to see this.
@@ -31,59 +48,116 @@ define([
                     </div>
                 </div>
                 <div class='panel-body collapse' id="globalFeedInput">
-                    <div class='form-group mx-sm-3 mb-2'>
-                        <label for="verb-select"><b>Verb</b> - this tells the notification what's happening.</label>
-                        <select class="form-control custom-select" id="verb-select">
-                            ${verbs.map(verb => `<option value="${verb}">${verb}</option>`)}
-                        </select>
+                    <div class='form-group'>
+                        <label for="context-text">Notification text</label>
+                        <input type="text" class="form-control" id="context-text" placeholder="Set the notification text here"></input>
                     </div>
-                    <div class='form-group mx-sm-3 mb-2'>
-                        <label for="object-input"><b>Object</b> - this field sets the notification to what the event is affecting.</label>
-                        <input class="form-control" id="object-input" placeholder="Enter object" />
-                        <small class="form-text text-muted"></small>
+                    <div class='form-group'>
+                        <label for="context-text">Notification link</label>
+                        <input type="text" class="form-control" id="context-link" placeholder="Add an optional hyperlink here"></input>
                     </div>
+
                     <div class='form-group mx-sm-3 mb-2'>
-                        <label for="level-select"><b>Level</b> - this sets the "importance" of a notification, useful for filtering</label>
+                        <label for="level-select"><b>Level</b> - this sets the "importance" of a notification</label>
                         <select class="form-control custom-select" id="level-select">
                             ${levels.map(level => `<option value="${level}">${level}</option>`)}
                         </select>
                     </div>
-                    <div class='form-group mx-sm-3 mb-2'>
-                        <label for="expiration"><b>Expiration</b> - adds an expiration time when the notification disappears</label>
-                        <input type="text" class="form-control" id="expiration-time" placeholder="Enter a timestamp (ms since epoch. I know. I'll try to make this better before the demo.)"></input>
-                    </div>
-                    <div class='form-group mx-sm-3 mb-2'>
-                        <label for="context-input"><b>Context keys</b> - these are optional. If present, they will provide a link and specific text for the notification</label>
-                        <div class="input-group mb-3">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text">Text</span>
-                            </div>
-                            <input type="text" class="form-control" placeholder="Optional text for the notification" id="context-text">
-                        </div>
-                        <div class="input-group mb-3">
-                            <div class="input-group-prepend">
-                                <span class="input-group-text">Link</span>
-                            </div>
-                            <input type="text" class="form-control" placeholder="Link for the notification to link out to" id="context-link">
-                        </div>
+                    <label for="expiration"><b>Expiration</b> - adds an expiration time when the notification disappears (24h format)</label>
+                    <div class='form-group form-inline' id="expiration">
+                        <label for="exp-year">Year</label>
+                        <input type="number" class="form-control" id="exp-year" placeholder="YYYY" min=2019 value=${defaultExp.getFullYear()}></input>
+                        <label for="exp-mon">Month</label>
+                        <select class="form-control" id="exp-mon">
+                            ${this.generateMonths(defaultExp)}
+                        </select>
+                        <label for="exp-day">Day</label>
+                        <input type="number" class="form-control" id="exp-day" placeholder="DD" value=${defaultExp.getDate()} min=1 max=31></input>
+                        <label for="exp-hour">Hour</label>
+                        <input type="number" class="form-control" id="exp-hour" min=0 max=23 value=${defaultExp.getHours()} placeholder="HH"></input>
+                        <label for="exp-min">Minute</label>
+                        <input type="number" class="form-control" id="exp-min" min=0 max=59 value=${defaultExp.getMinutes()} placeholder="MM"></input>
                     </div>
                     <button type="submit" class="btn btn-primary mb-2" id="postGlobal">Submit</button>
                 </div>`;
             this.bindEvents();
         }
 
+        generateMonths(date) {
+            let curMonth = date.getMonth();
+            let months = [
+                'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
+                'September', 'October', 'November', 'December'
+            ].map((m, i) => {
+                let selected = i === curMonth ? ' selected' : '';
+                return '<option value=' + i + selected + '>' + m + '</option>';
+            });
+            return months;
+        }
+
+        validateDay(day, month, year) {
+            return new Date(year, month, day).getDate() === day;
+        }
+
+        getExpirationTimestamp() {
+            let curDate = new Date();
+            let year = parseInt(this.element.querySelector('#exp-year').value),
+                month = parseInt(this.element.querySelector('#exp-mon').value),
+                day = parseInt(this.element.querySelector('#exp-day').value),
+                hour = parseInt(this.element.querySelector('#exp-hour').value),
+                min = parseInt(this.element.querySelector('#exp-min').value),
+                sec = curDate.getSeconds(),
+                fail = false;
+
+            // error trapping here
+            if (isNaN(year) || year < curDate.getFullYear()) {
+                alert('Year must be a number >= ' + curDate.getFullYear());
+                fail = true;
+            }
+            else if (isNaN(month) || (month < curDate.getMonth() && year === curDate.getFullYear())) {
+                alert('Month must not be set to something in the past.');
+                fail = true;
+            }
+            else if (isNaN(day) || day <= 0 || !this.validateDay(day, month, year)) {
+                alert('Day is either not a number, or invalid for the selected month');
+                fail = true;
+            }
+            else if (isNaN(hour) || hour < 0 || hour > 23) {
+                alert('Hour must be a number between 0 and 23');
+                fail = true;
+            }
+            else if (isNaN(min) || min < 0 || min > 59) {
+                alert('Minute must be a number between 0 and 59');
+                fail = true;
+            }
+
+            let expDate = new Date(year, month, day, hour, min, sec);
+            if (expDate <= curDate) {
+                alert("Don't expire the notification before it's made, please.");
+                fail = true;
+            }
+            if (fail) {
+                return null;
+            }
+            return expDate.getTime();
+        }
+
         bindEvents() {
             this.element.querySelector('#postGlobal').onclick = () => {
-                let verb = this.element.querySelector('#verb-select').value,
-                    object = this.element.querySelector('#object-input').value,
+                let verb = 'update', //this.element.querySelector('#verb-select').value,
+                    object = 'none', //this.element.querySelector('#object-input').value,
                     level = this.element.querySelector('#level-select').value,
                     contextText = this.element.querySelector('#context-text').value,
                     contextLink = this.element.querySelector('#context-link').value,
-                    expiration = parseInt(this.element.querySelector('#expiration-time').value),
+                    expiration = this.getExpirationTimestamp(),
                     feedsApi = FeedsAPI.make(
                         this.runtime.getConfig('services.feeds.url'),
                         this.runtime.service('session').getAuthToken()
                     );
+                if (expiration === null) {
+                    console.error('Illegal expiration!');
+                    return;
+                }
                 feedsApi.postGlobalNotification({
                     verb: verb,
                     object: object,

--- a/src/plugin/modules/components/notification.js
+++ b/src/plugin/modules/components/notification.js
@@ -32,6 +32,7 @@ define([
          * - refreshFn - called when something gets marked seen/unseen
          * - showSeen - boolean, if true, shows an icon of whether a notification has been seen
          * - runtime - the runtime object
+         * - canExpire - boolean, if true, this notification can be expired and removed.
          */
         constructor(note, toggleSeenFn) {
             this.note = note;

--- a/src/plugin/modules/components/notification.js
+++ b/src/plugin/modules/components/notification.js
@@ -32,12 +32,13 @@ define([
          * - refreshFn - called when something gets marked seen/unseen
          * - showSeen - boolean, if true, shows an icon of whether a notification has been seen
          * - runtime - the runtime object
-         * - canExpire - boolean, if true, this notification can be expired and removed.
+         * - expireNoteFn - if note null, then this notification can be expired by the user (which means gone forever)
          */
-        constructor(note, toggleSeenFn) {
+        constructor(note, toggleSeenFn, expireNoteFn) {
             this.note = note;
             this.noteObj = this.makeNoteObj();
             this.toggleSeenFn = toggleSeenFn;
+            this.expireNoteFn = expireNoteFn;
             this.element = document.createElement('div');
             this.element.classList.add('feed-note');
             if (this.note.seen) {
@@ -59,7 +60,7 @@ define([
             let level = div({class: 'feed-note-icon'}, [this.renderLevel()]),
                 body = div({class: 'feed-note-body'}, [this.renderBody()]),
                 link = div({class: 'feed-link'}, [this.renderLink()]),
-                control = div({class: 'feed-note-control'}, [this.renderControl()]);
+                control = div({class: 'feed-note-control'}, this.renderControl());
             this.element.innerHTML = level + body + link + control;
             this.bindEvents();
         }
@@ -74,21 +75,40 @@ define([
          * Renders controls for dismissing/marking a notification seen.
          */
         renderControl() {
-            if (!this.toggleSeenFn) {
-                return '';
-            }
+            let seenBtn = '';
             let icon = this.note.seen ? 'eye-slash' : 'eye';
             let text = this.note.seen ? 'unseen' : 'seen';
-            let btn = span(
-                i({
-                    class: 'fa fa-' + icon,
-                    dataToggle: 'tooltip',
-                    dataPlacement: 'left',
-                    title: 'Mark ' + text,
-                    style: 'cursor: pointer'
-                })
-            );
-            return btn;
+            if (this.toggleSeenFn) {
+                seenBtn = span(
+                    {
+                        class: 'feed-seen'
+                    },
+                    i({
+                        class: 'fa fa-' + icon,
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'left',
+                        title: 'Mark ' + text,
+                        style: 'cursor: pointer'
+                    })
+                );
+            }
+
+            let expBtn = '';
+            if (this.expireNoteFn) {
+                expBtn = span(
+                    {
+                        class: 'feed-expire'
+                    },
+                    i({
+                        class: 'fa fa-times',
+                        dataToggle: 'tooltip',
+                        dataPlacement: 'left',
+                        title: 'Expire this notification',
+                        style: 'cursor: pointer'
+                    })
+                );
+            }
+            return [seenBtn, expBtn];
         }
 
         renderLink() {
@@ -159,9 +179,13 @@ define([
 
         bindEvents() {
             $(this.element).find('[data-toggle="tooltip"]').tooltip();
-            let seenBtn = this.element.querySelector('.feed-note-control span');
+            let seenBtn = this.element.querySelector('.feed-note-control span.feed-seen');
             if (seenBtn) {
                 seenBtn.onclick = () => this.toggleSeenFn(this.note);
+            }
+            let expireBtn = this.element.querySelector('.feed-note-control span.feed-expire');
+            if (expireBtn) {
+                expireBtn.onclick = () => this.expireNoteFn(this.note);
             }
         }
     }


### PR DESCRIPTION
Update how a global notification gets made
* UI requires a text field now, to avoid confusion
* Added a (better, still not great) expiration time solution
* Removed object field, because it didn't make sense for globals
* Set verb to always be "update"

Add ability for admins to delete global notifications
* mouseover globals shows a deletion key for users with FEEDS_ADMIN role.
* clicking it makes a verify popup
* clicking ok there expires the notification and refreshes the feed