### PR TITLE
don't redeclare variable - breaks minified build

### DIFF
--- a/src/plugin/modules/notifications/base.js
+++ b/src/plugin/modules/notifications/base.js
@@ -1,6 +1,6 @@
 define([
     '../util'
-], function(
+], function (
     Util
 ) {
     'use strict';
@@ -28,21 +28,21 @@ define([
 
         buildHtml() {
             let actor = this.actorHtml(),
-                msg;
-            switch(this.note.verb) {
+                msg, obj;
+            switch (this.note.verb) {
             case 'invited':
-                let obj = this.note.object;
+                obj = this.note.object;
                 msg = actor + ' ' + this.note.verb + ' you to join the group ' + (obj.name ? obj.name : obj.id);
                 break;
             case 'shared':
                 msg = actor + ' ' + this.note.verb + ' with you.';
                 break;
             case 'requested':
-                let obj = this.note.object;
+                obj = this.note.object;
                 msg = actor + ' ' + this.note.verb + ' to join the group ' + (obj.name ? obj.name : obj.id);
                 break;
             default:
-                let obj = this.note.object;
+                obj = this.note.object;
                 msg = actor + ' ' + this.note.verb + ' ' + (obj.name ? obj.name : obj.id);
             }
             return msg;


### PR DESCRIPTION
This change moves the declaration of obj to the top of the function, since redeclaring it in the case branches is an error.

could also use a block within the case branches, but making minimal change.

doing a kbase-ui build with a build type of "ci" will catch this sort of thing, since the minified failed on syntax errors. the regular dev build could perhaps do a syntax check as well, at least running the linter and refusing to build with lint errors (although we would need to put eslint exception comments in files which are purposefully breaking the linter...)